### PR TITLE
Run macOS visual regression once per PR

### DIFF
--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -1,0 +1,16 @@
+name: visual-regression
+
+on:
+  pull_request:
+  push:
+    branches: [master]
+
+jobs:
+  test:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v1
+        with:
+          bun-version: 1.2.14
+      - run: bunx playwright install webkit


### PR DESCRIPTION
## Summary
- revert prior commit adding libghostty-wasm demo
- add macOS workflow for visual regression, triggered only on pull requests or master pushes

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6891219f9bf08320b9c0027cf32e76f3